### PR TITLE
Add `declare` keyword to `namespace` node at root layer and remove `namespace` nodes when the `class` with the same name are removed

### DIFF
--- a/fixtures/proto.d.ts
+++ b/fixtures/proto.d.ts
@@ -19,6 +19,83 @@ export namespace root {
       metadata?: { [k: string]: string } | null;
     }
 
+    class AdminService extends $protobuf.rpc.Service {
+
+      /**
+       * Constructs a new AdminService service.
+       * @param rpcImpl RPC implementation
+       * @param [requestDelimited=false] Whether requests are length-delimited
+       * @param [responseDelimited=false] Whether responses are length-delimited
+       */
+      constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
+
+      /**
+       * Calls ListOperationConfig.
+       * @param request ListOperationConfigRequest message or plain object
+       * @param callback Node-style callback called with the error, if any, and ListOperationConfigResponse
+       */
+      public listOperationConfig(request: love.api.v1.IListOperationConfigRequest, callback: love.api.v1.AdminService.ListOperationConfigCallback): void;
+
+      /**
+       * Calls ListOperationConfig.
+       * @param request ListOperationConfigRequest message or plain object
+       * @returns Promise
+       */
+      public listOperationConfig(request: love.api.v1.IListOperationConfigRequest): Promise<love.api.v1.ListOperationConfigResponse>;
+
+      /**
+       * Calls ListAnnouncement.
+       * @param request ListAnnouncementRequest message or plain object
+       * @param callback Node-style callback called with the error, if any, and ListAnnouncementResponse
+       */
+      public listAnnouncement(request: love.api.v1.IListAnnouncementRequest, callback: love.api.v1.AdminService.ListAnnouncementCallback): void;
+
+      /**
+       * Calls ListAnnouncement.
+       * @param request ListAnnouncementRequest message or plain object
+       * @returns Promise
+       */
+      public listAnnouncement(request: love.api.v1.IListAnnouncementRequest): Promise<love.api.v1.ListAnnouncementResponse>;
+
+      /**
+       * Calls GetAnnouncement.
+       * @param request GetAnnouncementRequest message or plain object
+       * @param callback Node-style callback called with the error, if any, and GetAnnouncementResponse
+       */
+      public getAnnouncement(request: love.api.v1.IGetAnnouncementRequest, callback: love.api.v1.AdminService.GetAnnouncementCallback): void;
+
+      /**
+       * Calls GetAnnouncement.
+       * @param request GetAnnouncementRequest message or plain object
+       * @returns Promise
+       */
+      public getAnnouncement(request: love.api.v1.IGetAnnouncementRequest): Promise<love.api.v1.GetAnnouncementResponse>;
+  }
+
+  namespace AdminService {
+
+      /**
+       * Callback as used by {@link love.api.v1.AdminService#listOperationConfig}.
+       * @param error Error, if any
+       * @param [response] ListOperationConfigResponse
+       */
+      type ListOperationConfigCallback = (error: (Error|null), response?: love.api.v1.ListOperationConfigResponse) => void;
+
+      /**
+       * Callback as used by {@link love.api.v1.AdminService#listAnnouncement}.
+       * @param error Error, if any
+       * @param [response] ListAnnouncementResponse
+       */
+      type ListAnnouncementCallback = (error: (Error|null), response?: love.api.v1.ListAnnouncementResponse) => void;
+
+      /**
+       * Callback as used by {@link love.api.v1.AdminService#getAnnouncement}.
+       * @param error Error, if any
+       * @param [response] GetAnnouncementResponse
+       */
+      type GetAnnouncementCallback = (error: (Error|null), response?: love.api.v1.GetAnnouncementResponse) => void;
+  }
+
     /** class Enumerate */
     class Foo implements IFoo {
       /**

--- a/fixtures/proto.d.ts
+++ b/fixtures/proto.d.ts
@@ -1,5 +1,24 @@
 import * as $protobuf from "protobufjs";
 
+export namespace depth1 {
+  namespace depth2 {
+    namespace depth3{
+      interface IFoo {
+        /** Foo str */
+        str?: string | null;
+  
+        /** Foo bool */
+        bool?: boolean | null;
+  
+        /** Foo number */
+        num?: number | Long | null;
+  
+        /** Foo metadata */
+        metadata?: { [k: string]: string } | null;
+      }
+    }
+  }
+}
 /** Namespace root. */
 export namespace root {
   /** Namespace api. */

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -94,6 +94,21 @@ const transformer = (nsReplacement: NamespaceReplacement) => (
     return node;
   };
 
+  const shallowVisitor = (node: ts.Node): any => {
+    return ts.visitEachChild(node, n => {
+      if (ts.isModuleDeclaration(n)){
+        return ts.updateModuleDeclaration(
+          n,
+          n.decorators,
+          [...n.modifiers!, ts.createModifier(ts.SyntaxKind.DeclareKeyword)],
+          n.name,
+          n.body
+        );
+      }
+      return n;
+    }, context);
+  }
+
   const visitor = (node: ts.Node): any => {
     node = ts.visitEachChild(node, visitor, context);
 
@@ -203,6 +218,7 @@ const transformer = (nsReplacement: NamespaceReplacement) => (
 
   rootNode = ts.visitNode(rootNode, visitor);
   rootNode = ts.visitNode(rootNode, removeNamespaceVisitor);
+  rootNode = ts.visitNode(rootNode, shallowVisitor);
 
   // Append formatted `enum` list to node statements
   rootNode.statements = <any>[...rootNode.statements, ...enumList];


### PR DESCRIPTION
2 changes are made in this pull request.

### Add `declare` keyword to `namespace` node at root layer

File Input
```
export namespace depth1 {
  namespace depth2 { }
}

export namespace depth3 {
  namespace depth4 {
    namespace depth5  { }
  }
}
```
File Output
```
export declare namespace depth1 {
  namespace depth2 { }
}

export declare namespace depth3 {
  namespace depth4 {
    namespace depth5  { }
  }
}
```

### Remove `namespace` nodes when the `class` with the same name are removed

File Input
```
export namespace root {
  class cute1 {}
  namespace cute1 {}
  namespace cute2 {}
}
```

File Output
```
export namespace root {
  namespace cute2 {}
}
```