### PR TITLE
feat: remove long import statement

### DIFF
--- a/fixtures/proto.d.ts
+++ b/fixtures/proto.d.ts
@@ -1,4 +1,5 @@
 import * as $protobuf from "protobufjs";
+import Long = require("long");
 
 /** Namespace root. */
 export namespace root {

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -100,6 +100,16 @@ const transformer =
         return undefined;
       }
 
+      // Remove `long`
+      if (
+        ts.isImportEqualsDeclaration(node) &&
+        ts.isExternalModuleReference(node.moduleReference) &&
+        ts.isStringLiteral(node.moduleReference.expression) &&
+        node.moduleReference.expression.text === 'long'
+      ) {
+        return undefined;
+      }
+
       // Remove `class` definition
       if (ts.isClassDeclaration(node)) {
         classList.add(node.name!.escapedText.toString());


### PR DESCRIPTION
protobuf.js cli emits a import statement of `Long` type after 6.9.0  (https://github.com/protobufjs/protobuf.js/pull/1166)
However, we remove all `Long` type references, so I added an implemention that removes this statement.